### PR TITLE
Fix SSH debug causing master control sockets to fail

### DIFF
--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -230,12 +230,17 @@ sub pingone ($$){
         DEBUG("$debug_key: Master Control Socket file: $master_control_socket_path_file does not exist!  Creating new socket file.\n");
       }
 
-      my $openssh_detail = "-vvv" if $debug_ssh;
+      my @master_opts = (
+        "-oStrictHostKeyChecking=no",
+        "-oControlPersist=$multiplex_control_persist_time",
+      );
+      push @master_opts, "-vvv" if $debug_ssh;
 
       # Append options hash to create a multiplex control socket
       $opts{'ctl_dir'} = $master_control_socket_dir;
       $opts{'ctl_path'} = $master_control_socket_path_file;
-      $opts{'master_opts'} = ["-oStrictHostKeyChecking=no", "-oControlPersist=$multiplex_control_persist_time", $openssh_detail];
+      $opts{'master_opts'} = \@master_opts;
+    }
     }
   } else {
     # $self->do_log("Not using OpenSSH ControlMaster Multiplex connections!\n");


### PR DESCRIPTION
Fixes a bug when $openssh_detail is undef (SSH debugging disabled) causing the master control socket to fail to create.

While ssh_debug is disabled, logs like below are generated by Smokeping and master control sockets don't get created.
```
Use of uninitialized value $call[3] in exec at /usr/share/perl5/Net/OpenSSH.pm line 1014
OpenSSHMikrotikRouterOSPing: OpenSSHMikrotikRouterOSPing connecting <source IP>: unable to establish master SSH connection: bad password or master process exited unexpectedly
```