### PR TITLE
Fixes 'host unreachable' counting as responses from target. Adds SSH key auth. Adds a little more detail to debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,25 @@
      key_path and password in the same call.  Now ssh_key_path takes
      precedence over routerospass so targets can flip individual
      entries to key auth without unsetting the probe-level default.
+### Version 1.4.8
+- debug=true output now starts with a one-line cycle-start summary
+  (host, dest, user, auth method, multiplex, timeouts, strict-host-key
+  policy) and ends with a cycle-done summary including phase timings
+  (connect / command / parse / total) and the parsed sample count.
+  Makes "why is this probe slow?" answerable without enabling
+  debug_ssh.
+- debug=true now logs the full composed ssh invocation (ssh_binary_path
+  + master_opts + -p port + user@host + quoted ping command).  Copy-
+  paste this as the smokeping user to reproduce connection failures
+  manually.
+- The RouterOS "sent=N received=N packet-loss=N%" footer line is no
+  longer silently discarded.  debug=true now logs it and cross-checks
+  the router's received count against the parser's sample count,
+  emitting a "WARN parser drift" line on mismatch.  Surfaces parser
+  regressions against new RouterOS output formats.
+- Documentation (POD, MANPAGE.md, README.md) now carries a prominent
+  security warning that debug_logfile contains routerospass in
+  plaintext (via the existing Net::OpenSSH options Dumper dump) and
+  the on-disk path of ssh_key_path.  If you have previously run with
+  debug=true, rotate or redact any historical debug_logfile files
+  before sharing them externally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,9 @@
   the on-disk path of ssh_key_path.  If you have previously run with
   debug=true, rotate or redact any historical debug_logfile files
   before sharing them externally.
+- Fixed latent regression from 1.4.5: Net::OpenSSH forbids master_opts
+  alongside external_master=1, so reusing an existing multiplex
+  control socket would fail with "Invalid or bad combination of
+  options ('master_opts')" once a socket persisted between probe
+  cycles.  master_opts is now dropped from %opts on the socket-reuse
+  path.  Fresh-master creation path is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,14 @@
   had been introduced in commit dce8918 and prevented the .pm from
   loading under Perl. This fix is a side-effect of the master_opts
   restructure.
+### Version 1.4.6
+- Added ssh_key_path target var for SSH key-based authentication. When
+  set, the ssh client is invoked with -i <path> and routerospass is
+  bypassed.
+- routerospass is now optional (removed from the _mandatory list).
+  Targets may authenticate via routerospass, ssh_key_path, or by leaving
+  both unset and relying on ssh-agent / default identity files (useful
+  for containerised smokeping deployments that mount SSH_AUTH_SOCK).
+- README documents the full MikroTik-side setup (ssh-keygen, scp, /user
+  ssh-keys import) and shows all three auth modes in the target
+  examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,20 @@
   pings. The time regex is now anchored to end-of-line so only replies with
   an empty STATUS column are recorded; anything else is treated as a dropped
   packet, matching MikroTik's own packet-loss accounting.
+### Version 1.4.5
+- Added ssh_connect_timeout target var (default 10s) mapped to OpenSSH's
+  -oConnectTimeout. Unreachable routers now fail within a few seconds
+  instead of blocking the probe for the full session timeout.
+- Added ssh_timeout target var (default 60s) exposing the Net::OpenSSH
+  master-channel timeout that was previously hardcoded.
+- Added ssh_strict_host_key_checking target var (default accept-new)
+  replacing the previous hardcoded StrictHostKeyChecking=no behaviour
+  that only applied in the multiplex branch. The new default auto-adds
+  host keys on first connect but fails loud on key changes. Applied
+  consistently whether multiplexing is enabled or not.
+- Net::OpenSSH now invoked with kill_ssh_on_timeout=1 so timed-out ssh
+  subprocesses are cleaned up rather than lingering.
+- Removed a stray closing brace in the multiplex-new-master branch that
+  had been introduced in commit dce8918 and prevented the .pm from
+  loading under Perl. This fix is a side-effect of the master_opts
+  restructure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,17 @@
 - README documents the full MikroTik-side setup (ssh-keygen, scp, /user
   ssh-keys import) and shows all three auth modes in the target
   examples.
+### Version 1.4.7
+- Fixed two separate "Invalid or bad combination of options ..." errors
+  from Net::OpenSSH introduced by the 1.4.6 auth changes:
+  1. "(22, key_path, 60, 1, 0)" when routerospass was unset.  The %opts
+     hash was using the "key" => ($val ? $val : ()) idiom, which
+     flattens to a bare "key" (no value) when $val is falsy, producing
+     an odd-element list that pairs subsequent keys and values into the
+     wrong slots.  Replaced with ($val ? (key => $val) : ()) so the
+     whole pair is added or omitted atomically.
+  2. "(key_path)" when a target with ssh_key_path set inherited
+     routerospass from the probe-level default.  Net::OpenSSH refuses
+     key_path and password in the same call.  Now ssh_key_path takes
+     precedence over routerospass so targets can flip individual
+     entries to key auth without unsetting the probe-level default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,9 @@
   created if debug = true was not set on target
 - Corrected documentation referring to Target Host SSH Port, should be Source
   SSH POrt
+### Version 1.4.4
+- Fixed issue where replies with a non-empty STATUS column (e.g. "host
+  unreachable" returned by an intermediate hop) were counted as successful
+  pings. The time regex is now anchored to end-of-line so only replies with
+  an empty STATUS column are recorded; anything else is treated as a dropped
+  packet, matching MikroTik's own packet-loss accounting.

--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -317,7 +317,7 @@ VARIABLES
         duration of the ssh session including the running ping command, so
         it must be larger than the ping command duration (roughly pings *
         1s + headroom). For short TCP handshake timeouts see
-        ssh_connect_timeout.
+        ssh_connect_timeout. This must be lower than 'step'.
 
         Example value: 60
 
@@ -354,10 +354,13 @@ NOTES
         legacy default.
 
     *   SSH key file: set ssh_key_path to the path of a private key file
-        readable by the user running smokeping. Leave routerospass unset.
-        Install the matching public key on the router with /user ssh-keys
-        import public-key-file=<file> user=<routerosuser>. The README has
-        a step-by-step walk-through.
+        readable by the user running smokeping. When ssh_key_path is set
+        it takes precedence over any routerospass inherited from the
+        probe-level default, so you can flip individual targets to key
+        auth without having to unset routerospass on the parent. Install
+        the matching public key on the router with /user ssh-keys import
+        public-key-file=<file> user=<routerosuser>. The README has a
+        step-by-step walk-through.
 
     *   ssh-agent or system default identity: leave both routerospass and
         ssh_key_path unset. Net::OpenSSH will invoke the system ssh client

--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -33,7 +33,10 @@ SYNOPSIS
      rtable = secondary_route
      source = 192.168.2.1 # mandatory
      ssh_binary_path = /usr/bin/ssh
+     ssh_connect_timeout = 10
      ssh_port = 22431
+     ssh_strict_host_key_checking = accept-new
+     ssh_timeout = 60
      ttl = 20
 
      # [...]
@@ -62,7 +65,10 @@ SYNOPSIS
      rtable = secondary_route
      source = 192.168.2.1 # mandatory
      ssh_binary_path = /usr/bin/ssh
+     ssh_connect_timeout = 10
      ssh_port = 22431
+     ssh_strict_host_key_checking = accept-new
+     ssh_timeout = 60
      ttl = 20
 
 DESCRIPTION
@@ -259,6 +265,17 @@ VARIABLES
 
         Default value: /usr/bin/ssh
 
+    ssh_connect_timeout
+        The (optional) ssh_connect_timeout option bounds the TCP/SSH
+        handshake in seconds via OpenSSH's ConnectTimeout option. This is
+        the main knob for failing fast when the Mikrotik RouterOS device is
+        unreachable, so probe cycles do not blow out waiting the full
+        ssh_timeout. Must be less than ssh_timeout.
+
+        Example value: 10
+
+        Default value: 10
+
     ssh_port
         The (optional) ssh_port option lets you specify a non standard SSH
         port.
@@ -266,6 +283,30 @@ VARIABLES
         Example value: 22431
 
         Default value: 22
+
+    ssh_strict_host_key_checking
+        The (optional) ssh_strict_host_key_checking option controls
+        OpenSSH's StrictHostKeyChecking policy for the ssh connection to
+        the Mikrotik RouterOS device. Valid values: 'accept-new' (default
+        - auto-adds new host keys to known_hosts on first connect, rejects
+        changed keys), 'no' (silently trust any host key), 'yes' (require
+        key to already be in known_hosts, fail otherwise).
+
+        Example value: accept-new
+
+        Default value: accept-new
+
+    ssh_timeout
+        The (optional) ssh_timeout option specifies, in seconds, the
+        Net::OpenSSH master-channel timeout. This bounds the overall
+        duration of the ssh session including the running ping command, so
+        it must be larger than the ping command duration (roughly pings *
+        1s + headroom). For short TCP handshake timeouts see
+        ssh_connect_timeout.
+
+        Example value: 60
+
+        Default value: 60
 
     ttl The (optional) ttl option lets you specify the Time to Live value
         for the pings sent. Default is 64.
@@ -289,11 +330,15 @@ NOTES
     and the ssh server must not be disabled. You can use a non standard
     port.
 
-    Make sure to connect to the remote host once from the command line as
-    the user who is running smokeping. On the first connect ssh will ask to
-    add the new host to its known_hosts file. This will not happen
-    automatically so the script will fail to login until the ssh key of your
-    Mikrotik RouterOS device is in the known_hosts file.
+    By default (ssh_strict_host_key_checking=accept-new) the probe will add
+    the router's host key to the smokeping user's known_hosts file
+    automatically on first connect. If the key later changes (router
+    rebuild, replacement, or a man-in-the-middle) the connection will fail
+    until the stale entry is removed from known_hosts, which is the
+    intended behaviour for a monitoring tool. Set
+    ssh_strict_host_key_checking=no to trust any key silently, or
+    ssh_strict_host_key_checking=yes to require the key be pre-populated in
+    known_hosts before the probe will connect.
 
   Requirements
     This module requires the Net::OpenSSH and IO::Pty perl modules

--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -28,11 +28,12 @@ SYNOPSIS
      multiplex_ssh = false
      pings = 20
      psource = 192.168.2.129
-     routerospass = password # mandatory
+     routerospass = password # optional - see Authentication notes
      routerosuser = user # mandatory
      rtable = secondary_route
      source = 192.168.2.1 # mandatory
      ssh_binary_path = /usr/bin/ssh
+     ssh_key_path = /etc/smokeping/id_ed25519
      ssh_connect_timeout = 10
      ssh_port = 22431
      ssh_strict_host_key_checking = accept-new
@@ -60,11 +61,12 @@ SYNOPSIS
      multiplex_ssh = false
      pings = 20
      psource = 192.168.2.129
-     routerospass = password # mandatory
+     routerospass = password # optional - see Authentication notes
      routerosuser = user # mandatory
      rtable = secondary_route
      source = 192.168.2.1 # mandatory
      ssh_binary_path = /usr/bin/ssh
+     ssh_key_path = /etc/smokeping/id_ed25519
      ssh_connect_timeout = 10
      ssh_port = 22431
      ssh_strict_host_key_checking = accept-new
@@ -224,12 +226,13 @@ VARIABLES
         Example value: 192.168.2.129
 
     routerospass
-        The (manditory) routerospass option allows you to specify the SSH
-        login password.
+        The (optional) routerospass option specifies the SSH login
+        password. Required unless ssh_key_path is set, or ssh-agent / a
+        default identity file (e.g. ~/.ssh/id_ed25519) is configured for
+        the user running smokeping. See the Authentication section in the
+        notes.
 
         Example value: password
-
-        This setting is mandatory.
 
     routerosuser
         The (manditory) routerosuser option allows you to specify the SSH
@@ -264,6 +267,18 @@ VARIABLES
         Example value: /usr/bin/ssh
 
         Default value: /usr/bin/ssh
+
+    ssh_key_path
+        The (optional) ssh_key_path option specifies the path to a private
+        key file used to authenticate to the Mikrotik RouterOS device. When
+        set the ssh client is invoked with -i <path>, bypassing
+        routerospass. The key must be readable only by the user running
+        smokeping (typically mode 0600) or the ssh client will refuse to
+        use it. See the Authentication section in the notes for the three
+        supported modes (password, key file, ssh-agent / default identity
+        files).
+
+        Example value: /etc/smokeping/id_ed25519
 
     ssh_connect_timeout
         The (optional) ssh_connect_timeout option bounds the TCP/SSH
@@ -326,9 +341,33 @@ AUTHORS
 
 NOTES
   Mikrotik RouterOS configuration
-    The Mikrotik RouterOS device should have a username/password configured,
-    and the ssh server must not be disabled. You can use a non standard
-    port.
+    The Mikrotik RouterOS device should have a username configured, and the
+    ssh server must not be disabled. You can use a non standard port. The
+    user needs either a password set or an ssh public key associated with
+    it via /user ssh-keys import on the router.
+
+  Authentication
+    The probe supports three ways to authenticate to the Mikrotik RouterOS
+    device. Pick one per target.
+
+    *   Password: set routerospass. Leave ssh_key_path unset. This is the
+        legacy default.
+
+    *   SSH key file: set ssh_key_path to the path of a private key file
+        readable by the user running smokeping. Leave routerospass unset.
+        Install the matching public key on the router with /user ssh-keys
+        import public-key-file=<file> user=<routerosuser>. The README has
+        a step-by-step walk-through.
+
+    *   ssh-agent or system default identity: leave both routerospass and
+        ssh_key_path unset. Net::OpenSSH will invoke the system ssh client
+        which picks up SSH_AUTH_SOCK, ~/.ssh/id_ed25519, ~/.ssh/id_rsa
+        etc as it would for an interactive login. This is useful for
+        containerised smokeping deployments that mount an agent socket.
+
+    If none of the three are configured the connection will fail at
+    runtime with a Net::OpenSSH authentication error logged to the
+    smokeping log.
 
     By default (ssh_strict_host_key_checking=accept-new) the probe will add
     the router's host key to the smokeping user's known_hosts file

--- a/MANPAGE.md
+++ b/MANPAGE.md
@@ -134,7 +134,19 @@ VARIABLES
 
     debug
         The (optional) debug option lets you configure probe or target
-        specific debugging.
+        specific debugging. When enabled the log includes a cycle-start
+        configuration snapshot, the composed ssh command, phase timings
+        (connect/command/parse), and the RouterOS packet-loss summary
+        cross-checked against the parsed samples.
+
+        Security warning: with debug enabled the log also contains a
+        Data::Dumper dump of the Net::OpenSSH options hash, which
+        includes routerospass in plaintext when password auth is in use,
+        and the full on-disk path of ssh_key_path when key auth is in
+        use. Ensure debug_logfile lives on a filesystem readable only by
+        the smokeping user, and redact the file before sharing it
+        externally (support tickets, public issue trackers, pastebins,
+        etc.).
 
         Example value: true
 
@@ -142,7 +154,13 @@ VARIABLES
 
     debug_logfile
         The (optional) debug_logfile option lets you specify the debug
-        logifile
+        logifile.
+
+        With debug=true this file contains sensitive material including
+        the target's routerospass (when password auth is used) and the
+        on-disk path of ssh_key_path. Treat it as secret: lock it down
+        with filesystem permissions readable only by the smokeping user,
+        and rotate/redact it before sharing externally.
 
         Example value: /tmp/my_debug.log or /tmp/smokeping_target1.log
 
@@ -231,6 +249,10 @@ VARIABLES
         default identity file (e.g. ~/.ssh/id_ed25519) is configured for
         the user running smokeping. See the Authentication section in the
         notes.
+
+        Note: when debug=true the value of routerospass is written to
+        debug_logfile in plaintext as part of the Net::OpenSSH options
+        dump. See the debug option for details and mitigation.
 
         Example value: password
 

--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -47,8 +47,37 @@ DOC
   notes => <<DOC,
 ${e}head2 Mikrotik RouterOS configuration
 
-The Mikrotik RouterOS device should have a username/password configured, and
-the ssh server must not be disabled.  You can use a non standard port.
+The Mikrotik RouterOS device should have a username configured, and the
+ssh server must not be disabled.  You can use a non standard port.  The
+user needs either a password set or an ssh public key associated with it
+via /user ssh-keys import on the router.
+
+${e}head2 Authentication
+
+The probe supports three ways to authenticate to the Mikrotik RouterOS
+device.  Pick one per target.
+
+=over
+
+=item * Password: set routerospass.  Leave ssh_key_path unset.  This is
+the legacy default.
+
+=item * SSH key file: set ssh_key_path to the path of a private key
+file readable by the user running smokeping.  Leave routerospass unset.
+Install the matching public key on the router with /user ssh-keys
+import public-key-file=<file> user=<routerosuser>.  The README has a
+step-by-step walk-through.
+
+=item * ssh-agent or system default identity: leave both routerospass
+and ssh_key_path unset.  Net::OpenSSH will invoke the system ssh client
+which picks up SSH_AUTH_SOCK, ~/.ssh/id_ed25519, ~/.ssh/id_rsa etc as
+it would for an interactive login.  This is useful for containerised
+smokeping deployments that mount an agent socket.
+
+=back
+
+If none of the three are configured the connection will fail at runtime
+with a Net::OpenSSH authentication error logged to the smokeping log.
 
 By default (ssh_strict_host_key_checking=accept-new) the probe will add the
 router's host key to the smokeping user's known_hosts file automatically on
@@ -138,6 +167,7 @@ sub pingone ($$){
   my $ttl = $target->{vars}{ttl};
   my $do_not_fragment = $target->{vars}{do_not_fragment};
   my $ssh_cmd = $target->{vars}{ssh_binary_path};
+  my $ssh_key_path = $target->{vars}{ssh_key_path};
   my $ssh_timeout = $target->{vars}{ssh_timeout};
   my $ssh_connect_timeout = $target->{vars}{ssh_connect_timeout};
   my $ssh_strict_host_key_checking = $target->{vars}{ssh_strict_host_key_checking};
@@ -178,6 +208,7 @@ sub pingone ($$){
   my %opts = (
     "user" => $login ? $login : (),
     "password" => $password ? $password : (),
+    "key_path" => $ssh_key_path ? $ssh_key_path : (),
     "port" => $port,
     "timeout" => $ssh_timeout,
     "kill_ssh_on_timeout" => 1,
@@ -412,7 +443,7 @@ sub targetvars {
 
   # Define the parameters/options
   my $params = {
-    _mandatory => [ 'routerosuser', 'routerospass', 'source' ],
+    _mandatory => [ 'routerosuser', 'source' ],
     source => {
       _doc => <<DOC,
 The (manditory) source option specifies the Mikrotik RouterOS device that is going to run
@@ -444,7 +475,10 @@ DOC
     },
     routerospass => {
       _doc => <<DOC,
-The (manditory) routerospass option allows you to specify the SSH login password.
+The (optional) routerospass option specifies the SSH login password.
+Required unless ssh_key_path is set, or ssh-agent / a default identity
+file (e.g. ~/.ssh/id_ed25519) is configured for the user running
+smokeping.  See the Authentication section in the notes.
 DOC
       _example => 'password',
     },
@@ -537,6 +571,18 @@ necessary to define the path to the binary if it is not found in the \$PATH.
 DOC
       _default => "/usr/bin/ssh",
       _example => "/usr/bin/ssh",
+    },
+    ssh_key_path => {
+      _doc => <<DOC,
+The (optional) ssh_key_path option specifies the path to a private key
+file used to authenticate to the Mikrotik RouterOS device.  When set the
+ssh client is invoked with -i <path>, bypassing routerospass.  The key
+must be readable only by the user running smokeping (typically mode
+0600) or the ssh client will refuse to use it.  See the Authentication
+section in the notes for the three supported modes (password, key file,
+ssh-agent / default identity files).
+DOC
+      _example => '/etc/smokeping/id_ed25519',
     },
     ssh_connect_timeout => {
       _doc => <<DOC,

--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -314,7 +314,10 @@ sub pingone ($$){
         DEBUG("$debug_key: Master Control Socket file: $master_control_socket_path_file exists... Using.\n");
       }
 
-      # Append options hash to use existing multiplex control socket
+      # Append options hash to use existing multiplex control socket.
+      # Net::OpenSSH forbids master_opts alongside external_master (no master
+      # is being spawned, so master-side flags are meaningless), so drop it.
+      delete $opts{'master_opts'};
       $opts{'external_master'} = 1;
       $opts{'ctl_path'} = $master_control_socket_path_file;
     } else {

--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -63,10 +63,12 @@ device.  Pick one per target.
 the legacy default.
 
 =item * SSH key file: set ssh_key_path to the path of a private key
-file readable by the user running smokeping.  Leave routerospass unset.
-Install the matching public key on the router with /user ssh-keys
-import public-key-file=<file> user=<routerosuser>.  The README has a
-step-by-step walk-through.
+file readable by the user running smokeping.  When ssh_key_path is set
+it takes precedence over any routerospass inherited from the probe-level
+default, so you can flip individual targets to key auth without having
+to unset routerospass on the parent.  Install the matching public key
+on the router with /user ssh-keys import public-key-file=<file>
+user=<routerosuser>.  The README has a step-by-step walk-through.
 
 =item * ssh-agent or system default identity: leave both routerospass
 and ssh_key_path unset.  Net::OpenSSH will invoke the system ssh client
@@ -204,16 +206,25 @@ sub pingone ($$){
     DEBUG("$debug_key: Debugging enabled...\n");
   }
 
-  # Define the base SSH connection options to pass to the Net::OpenSSH->new() connection method
+  # Define the base SSH connection options to pass to the Net::OpenSSH->new() connection method.
+  # Note the conditional-pair idiom: ($val ? (key => $val) : ()) either adds both key and
+  # value, or adds neither.  The older form "key" => ($val ? $val : ()) produces a bare
+  # "key" with no value when $val is falsy, which corrupts the hash (odd element count).
+  #
+  # Auth precedence: ssh_key_path wins over routerospass.  Net::OpenSSH refuses to accept
+  # both key_path and password in the same call ("Invalid or bad combination of options"),
+  # so when a target sets ssh_key_path we drop any password inherited from the probe-level
+  # routerospass default.  If neither is set, Net::OpenSSH falls through to ssh-agent /
+  # default identity files.
   my %opts = (
-    "user" => $login ? $login : (),
-    "password" => $password ? $password : (),
-    "key_path" => $ssh_key_path ? $ssh_key_path : (),
-    "port" => $port,
-    "timeout" => $ssh_timeout,
+    ($login        ? ("user"     => $login       ) : ()),
+    ($ssh_key_path ? ("key_path" => $ssh_key_path)
+                   : ($password ? ("password" => $password) : ())),
+    "port"                => $port,
+    "timeout"             => $ssh_timeout,
     "kill_ssh_on_timeout" => 1,
-    "strict_mode" => 0,
-    "ssh_cmd" => $ssh_cmd
+    "strict_mode"         => 0,
+    "ssh_cmd"             => $ssh_cmd,
   );
 
   # Base master_opts applied whether or not multiplexing is enabled.

--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -19,6 +19,7 @@ use strict;
 use base qw(Smokeping::probes::basefork);
 use Net::OpenSSH;
 use Carp;
+use Time::HiRes qw(time);
 
 # Global VARs for Debugging & Multiplexing SSH Connections
 my $debug;
@@ -132,6 +133,27 @@ sub gen_debug_key(){
   return $str;
 }
 
+# Render a copy-pasteable approximation of the ssh invocation that
+# Net::OpenSSH will execute.  Useful for reproducing failures manually.
+# Does not include password auth details: Net::OpenSSH feeds the password
+# via a pty, not the command line, so the rendered command won't include
+# it.  key_path IS rendered (as -i <path>) because Net::OpenSSH translates
+# the key_path option into an -i flag on the underlying ssh invocation.
+sub render_ssh_command {
+  my ($ssh_cmd, $master_opts, $port, $user, $host, $key_path, $command) = @_;
+  my @parts = ($ssh_cmd, @$master_opts);
+  push @parts, "-i", $key_path if $key_path;
+  push @parts, "-p", $port if $port;
+  push @parts, ($user ? "$user\@$host" : $host);
+  # $command ends with "\n" (required by $ssh->capture for RouterOS CLI
+  # line termination) and may carry other trailing whitespace.  Strip it
+  # before wrapping in single quotes so the closing quote stays on the
+  # same log line.
+  (my $clean_command = $command) =~ s/\s+\z//;
+  push @parts, "'" . $clean_command . "'";
+  return join(" ", @parts);
+}
+
 # Check for existing multiplex configuration
 # in know locations
 sub check_for_multiplex_config($) {
@@ -189,6 +211,10 @@ sub pingone ($$){
 
   # If Debugging enabled
   $debug_key = gen_debug_key;
+  my $t_cycle_start = time();
+  my $auth_method = $ssh_key_path ? "key($ssh_key_path)"
+                  : $password     ? "password"
+                  :                 "agent/default";
   if ( $debug ) {
     use Data::Dumper;
 
@@ -203,7 +229,13 @@ sub pingone ($$){
         level => $DEBUG,
       }
     );
-    DEBUG("$debug_key: Debugging enabled...\n");
+    DEBUG(sprintf(
+      "%s: cycle start: host=%s dest=%s user=%s auth=%s multiplex=%s " .
+      "strict_host_key=%s connect_timeout=%ds timeout=%ds",
+      $debug_key, $host, $dest, $login, $auth_method,
+      ($multiplex_ssh ? "on" : "off"),
+      $ssh_strict_host_key_checking, $ssh_connect_timeout, $ssh_timeout,
+    ));
   }
 
   # Define the base SSH connection options to pass to the Net::OpenSSH->new() connection method.
@@ -272,7 +304,7 @@ sub pingone ($$){
       `chmod -R 0744 $master_control_socket_dir`;
 
       if ( $debug ) {
-        DEBUG("$debug_key: Multiplex control socket file path created and premissions set!");
+        DEBUG("$debug_key: Multiplex control socket file path created and permissions set!");
       }
     }
 
@@ -315,9 +347,11 @@ sub pingone ($$){
   }
 
   # Connect to source host
+  my $t_conn_start = time();
   my $ssh = Net::OpenSSH->new(
     $host, %opts
   );
+  my $t_conn_end = time();
 
   if ( $debug_ssh ) {
     DEBUG("SSH ERROR: " . $ssh->error );
@@ -366,14 +400,20 @@ sub pingone ($$){
 
   $ping_command .= "\n";
 
-  # Debug - Show ping command
+  # Debug - Show ping command + the full composed ssh invocation it will be sent through
   if ( $debug ) {
     DEBUG("$debug_key: $ping_command");
+    my $rendered = render_ssh_command(
+      $ssh_cmd, \@master_opts, $port, $login, $host, $ssh_key_path, $ping_command
+    );
+    DEBUG("$debug_key: ssh command: $rendered");
   }
 
   # Execute the ping command on the source/host and capture the response
   my @output = ();
+  my $t_cmd_start = time();
   @output = $ssh->capture($ping_command);
+  my $t_cmd_end = time();
 
   if ($ssh->error) {
     $self->do_log( "OpenSSHMikrotikRouterOSPing running commands on $host: ".$ssh->error );
@@ -388,18 +428,28 @@ sub pingone ($$){
 
   # Process the ping response
   my @times = ();
+  my $router_summary;
+  my $t_parse_start = time();
 
-  # Parse the ping latency values
+  # Parse the ping latency values.  The RouterOS summary footer "sent=N
+  # received=N packet-loss=N%" is captured separately so we can log it and
+  # cross-check the parser against the router's own accounting.  The
+  # min/avg/max-rtt footer line is still skipped to avoid accidentally
+  # matching the embedded rtt values with the sample-line regex.
   while (@output) {
     my $outputline = shift @output;
     chomp($outputline);
-    next if ($outputline =~ m/(sent|recieved|packet\-loss|min\-rtt|avg\-rtt|max\-rtt)/);
+    if ($outputline =~ /sent=(\d+)\s+received=(\d+)\s+packet-loss=(\d+)%/) {
+      $router_summary = { sent => $1, received => $2, loss => $3, raw => $outputline };
+      next;
+    }
+    next if ($outputline =~ m/(min\-rtt|avg\-rtt|max\-rtt)/);
     $outputline =~ /((\d+)ms(\d+)us|(\d+)ms|(\d+)us)\s*$/ && push(@times,($2?$2:"")+($4?$4:"")+($3?$3/1000:"")+($5?$5/1000:""));
   }
 
   # Convert the ping times values to RRD format
   @times = map {sprintf "%.10e", $_ / $self->{pingfactor}} sort {$a <=> $b} @times;
-  
+
   # Ensure the number of pings returned in @tumes are equal to the
   # configured number of pings defined in the host definition.  Any value
   # other than the number defined in the RRD format will cause the RRD update
@@ -408,12 +458,34 @@ sub pingone ($$){
   while (($length = @times) > 20) {
     pop @times;
   }
+  my $t_parse_end = time();
 
   # Debug
   if ( $debug ) {
     my $resp = Dumper \@times;
     my $length = @times;
     DEBUG("$debug_key: \@times result: length[$length]\n$resp\n");
+
+    if ( $router_summary ) {
+      DEBUG("$debug_key: router summary: $router_summary->{raw}");
+      if ( $router_summary->{received} != $length ) {
+        DEBUG(sprintf(
+          "%s: WARN parser drift: router received=%d but parser built %d samples",
+          $debug_key, $router_summary->{received}, $length,
+        ));
+      }
+    }
+
+    my $ms = sub { sprintf("%.0fms", ($_[1] - $_[0]) * 1000) };
+    DEBUG(sprintf(
+      "%s: cycle done: connect=%s command=%s parse=%s total=%s samples=%d",
+      $debug_key,
+      $ms->($t_conn_start,  $t_conn_end),
+      $ms->($t_cmd_start,   $t_cmd_end),
+      $ms->($t_parse_start, $t_parse_end),
+      $ms->($t_cycle_start, time()),
+      $length,
+    ));
   }
 
   return @times;
@@ -490,6 +562,10 @@ The (optional) routerospass option specifies the SSH login password.
 Required unless ssh_key_path is set, or ssh-agent / a default identity
 file (e.g. ~/.ssh/id_ed25519) is configured for the user running
 smokeping.  See the Authentication section in the notes.
+
+Note: when debug=true the value of routerospass is written to
+debug_logfile in plaintext as part of the Net::OpenSSH options dump.
+See the debug option for details and mitigation.
 DOC
       _example => 'password',
     },
@@ -697,7 +773,18 @@ DOC
     debug => {
       _doc => <<DOC,
 The (optional) debug option lets you configure probe or target specific
-debugging.
+debugging.  When enabled the log includes a cycle-start configuration
+snapshot, the composed ssh command, phase timings (connect/command/parse),
+and the RouterOS packet-loss summary cross-checked against the parsed
+samples.
+
+Security warning: with debug enabled the log also contains a
+Data::Dumper dump of the Net::OpenSSH options hash, which includes
+routerospass in plaintext when password auth is in use, and the full
+on-disk path of ssh_key_path when key auth is in use.  Ensure
+debug_logfile lives on a filesystem readable only by the smokeping user,
+and redact the file before sharing it externally (support tickets,
+public issue trackers, pastebins, etc.).
 DOC
       _default => 'false',
       _re => '\w+',
@@ -711,7 +798,13 @@ DOC
     },
     debug_logfile => {
       _doc => <<DOC,
-The (optional) debug_logfile option lets you specify the debug logifile
+The (optional) debug_logfile option lets you specify the debug logifile.
+
+With debug=true this file contains sensitive material including the
+target's routerospass (when password auth is used) and the on-disk path
+of ssh_key_path.  Treat it as secret: lock it down with filesystem
+permissions readable only by the smokeping user, and rotate/redact it
+before sharing externally.
 DOC
       _default => "/tmp/smokeping_debug.log",
       _example => "/tmp/my_debug.log or /tmp/smokeping_target1.log"

--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -338,7 +338,7 @@ sub pingone ($$){
     my $outputline = shift @output;
     chomp($outputline);
     next if ($outputline =~ m/(sent|recieved|packet\-loss|min\-rtt|avg\-rtt|max\-rtt)/);
-    $outputline =~ /((\d+)ms(\d+)us|(\d+)ms|(\d+)us)/ && push(@times,($2?$2:"")+($4?$4:"")+($3?$3/1000:"")+($5?$5/1000:""));
+    $outputline =~ /((\d+)ms(\d+)us|(\d+)ms|(\d+)us)\s*$/ && push(@times,($2?$2:"")+($4?$4:"")+($3?$3/1000:"")+($5?$5/1000:""));
   }
 
   # Convert the ping times values to RRD format

--- a/OpenSSHMikrotikRouterOSPing.pm
+++ b/OpenSSHMikrotikRouterOSPing.pm
@@ -50,11 +50,14 @@ ${e}head2 Mikrotik RouterOS configuration
 The Mikrotik RouterOS device should have a username/password configured, and
 the ssh server must not be disabled.  You can use a non standard port.
 
-Make sure to connect to the remote host once from the command line as the
-user who is running smokeping. On the first connect ssh will ask to add the
-new host to its known_hosts file. This will not happen automatically so the
-script will fail to login until the ssh key of your Mikrotik RouterOS device
-is in the known_hosts file.
+By default (ssh_strict_host_key_checking=accept-new) the probe will add the
+router's host key to the smokeping user's known_hosts file automatically on
+first connect. If the key later changes (router rebuild, replacement, or a
+man-in-the-middle) the connection will fail until the stale entry is
+removed from known_hosts, which is the intended behaviour for a monitoring
+tool. Set ssh_strict_host_key_checking=no to trust any key silently, or
+ssh_strict_host_key_checking=yes to require the key be pre-populated in
+known_hosts before the probe will connect.
 
 ${e}head2 Requirements
 
@@ -135,6 +138,9 @@ sub pingone ($$){
   my $ttl = $target->{vars}{ttl};
   my $do_not_fragment = $target->{vars}{do_not_fragment};
   my $ssh_cmd = $target->{vars}{ssh_binary_path};
+  my $ssh_timeout = $target->{vars}{ssh_timeout};
+  my $ssh_connect_timeout = $target->{vars}{ssh_connect_timeout};
+  my $ssh_strict_host_key_checking = $target->{vars}{ssh_strict_host_key_checking};
   my $multiplex_ssh = $target->{vars}{multiplex_ssh};
   $multiplex_control_socket_path = $target->{vars}{multiplex_control_socket_path};
   my $multiplex_control_persist_time = $target->{vars}{multiplex_control_persist_time};
@@ -173,10 +179,23 @@ sub pingone ($$){
     "user" => $login ? $login : (),
     "password" => $password ? $password : (),
     "port" => $port,
-    "timeout" => 60,
+    "timeout" => $ssh_timeout,
+    "kill_ssh_on_timeout" => 1,
     "strict_mode" => 0,
     "ssh_cmd" => $ssh_cmd
   );
+
+  # Base master_opts applied whether or not multiplexing is enabled.
+  # -oConnectTimeout bounds the TCP handshake so an unreachable router fails
+  # fast instead of waiting the full ssh_timeout. -oStrictHostKeyChecking
+  # defaults to accept-new so new routers auto-add on first connect but a
+  # changed key raises a visible failure in smokeping.
+  my @master_opts = (
+    "-oStrictHostKeyChecking=$ssh_strict_host_key_checking",
+    "-oConnectTimeout=$ssh_connect_timeout",
+  );
+  push @master_opts, "-vvv" if $debug_ssh;
+  $opts{'master_opts'} = \@master_opts;
 
   # If multiplex ssh is enabled
   if ( $multiplex_ssh ){
@@ -230,17 +249,12 @@ sub pingone ($$){
         DEBUG("$debug_key: Master Control Socket file: $master_control_socket_path_file does not exist!  Creating new socket file.\n");
       }
 
-      my @master_opts = (
-        "-oStrictHostKeyChecking=no",
-        "-oControlPersist=$multiplex_control_persist_time",
-      );
-      push @master_opts, "-vvv" if $debug_ssh;
+      # Add multiplex-specific options to the base master_opts list
+      push @master_opts, "-oControlPersist=$multiplex_control_persist_time";
 
       # Append options hash to create a multiplex control socket
       $opts{'ctl_dir'} = $master_control_socket_dir;
       $opts{'ctl_path'} = $master_control_socket_path_file;
-      $opts{'master_opts'} = \@master_opts;
-    }
     }
   } else {
     # $self->do_log("Not using OpenSSH ControlMaster Multiplex connections!\n");
@@ -523,6 +537,61 @@ necessary to define the path to the binary if it is not found in the \$PATH.
 DOC
       _default => "/usr/bin/ssh",
       _example => "/usr/bin/ssh",
+    },
+    ssh_connect_timeout => {
+      _doc => <<DOC,
+The (optional) ssh_connect_timeout option bounds the TCP/SSH handshake in
+seconds via OpenSSH's ConnectTimeout option.  This is the main knob for
+failing fast when the Mikrotik RouterOS device is unreachable, so probe
+cycles do not blow out waiting the full ssh_timeout.  Must be less than
+ssh_timeout.
+DOC
+      _default => 10,
+      _re => '\d+',
+      _sub => sub {
+        my $val = shift;
+        return "ERROR: ssh_connect_timeout value of $val is invalid.  Must be >= 1 and <= 300"
+          unless $val >= 1 and $val <= 300;
+        return undef;
+      },
+      _example => 10,
+    },
+    ssh_timeout => {
+      _doc => <<DOC,
+The (optional) ssh_timeout option specifies, in seconds, the Net::OpenSSH
+master-channel timeout.  This bounds the overall duration of the ssh
+session including the running ping command, so it must be larger than the
+ping command duration (roughly pings * 1s + headroom).  For short TCP
+handshake timeouts see ssh_connect_timeout.
+DOC
+      _default => 60,
+      _re => '\d+',
+      _sub => sub {
+        my $val = shift;
+        return "ERROR: ssh_timeout value of $val is invalid.  Must be >= 1 and <= 3600"
+          unless $val >= 1 and $val <= 3600;
+        return undef;
+      },
+      _example => 60,
+    },
+    ssh_strict_host_key_checking => {
+      _doc => <<DOC,
+The (optional) ssh_strict_host_key_checking option controls OpenSSH's
+StrictHostKeyChecking policy for the ssh connection to the Mikrotik
+RouterOS device.  Valid values: 'accept-new' (default - auto-adds new
+host keys to known_hosts on first connect, rejects changed keys), 'no'
+(silently trust any host key), 'yes' (require key to already be in
+known_hosts, fail otherwise).
+DOC
+      _default => 'accept-new',
+      _re => '(yes|accept-new|no)',
+      _sub => sub {
+        my $val = shift;
+        return "ERROR: ssh_strict_host_key_checking value of $val is invalid.  Must be yes, accept-new, or no"
+          unless $val eq 'yes' or $val eq 'accept-new' or $val eq 'no';
+        return undef;
+      },
+      _example => 'accept-new',
     },
     multiplex_ssh => {
       _doc => <<DOC,

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ I wanted a probe to connect to Mikrotik RouterOS devices via SSH. So I created t
 - Do Not Fragment flag
 - Source SSH Port (Standard or Non-Standard)
 - User defined openssh-client path (/usr/bin/ssh)
+- Configurable SSH connect timeout (fail fast when router is unreachable)
+- Configurable SSH session timeout
+- Configurable SSH StrictHostKeyChecking policy (`yes` / `accept-new` / `no`)
 - Multiplexed SSH Connections
   - User defined SSH Control Socket File Path
   - User defined SSH Control Socket Persist Timeout
@@ -152,6 +155,9 @@ pings = 20
 routerospass = <userpass>
 routerosuser = <username>
 # ssh_binary_path = /usr/bin/ssh
+# ssh_connect_timeout = 10 # Default.  Bounds TCP/SSH handshake; lower this to fail faster on unreachable routers.
+# ssh_timeout = 60 # Default.  Bounds the overall ssh session including the ping command.
+# ssh_strict_host_key_checking = accept-new # Default.  Other values: 'no' (trust any key), 'yes' (require pre-seeded known_hosts)
 multiplex_ssh = true # Default
 # multiplex_control_persist_time = 10 # Default is 10 min.  A value of 0 will leave socket file indefinitely
 # multiplex_control_file_path = ~/.libnet-openssh-perl # Default
@@ -196,6 +202,7 @@ source = <remoterouter1_WAN_IP_Address>
 # psource - No default defined, will use source address to source pings
 host = <IP_of_interest>
 ssh_port = 22431
+ssh_connect_timeout = 5 # Shorter than default 10s; fail fast if this remote router is down so the step doesn't blow out
 debug = true
 debug_logfile = /tmp/smokeping_remote_router1.log
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Multiplexing is the ability to send more than one signal over a single line or c
 The probe supports three ways to authenticate to each Mikrotik target, chosen per-target:
 
 1. **Password** — set `routerospass` (the legacy default).
-2. **SSH key file** — set `ssh_key_path` to the private key path. Leave `routerospass` unset.
+2. **SSH key file** — set `ssh_key_path` to the private key path. `ssh_key_path` takes precedence over any `routerospass` inherited from the probe-level default, so individual targets can flip to key auth without having to unset `routerospass` on the parent probe.
 3. **ssh-agent / default identity files** — leave both `routerospass` and `ssh_key_path` unset. Net::OpenSSH invokes the system ssh client which picks up `SSH_AUTH_SOCK`, `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, etc. — handy for containerised smokeping deployments that mount an agent socket.
 
 If none of the three are configured the connection fails at runtime with a Net::OpenSSH authentication error in the smokeping log.
@@ -117,8 +117,8 @@ chown smokeping:smokeping /etc/smokeping/id_ed25519 /etc/smokeping/id_ed25519.pu
 chmod 0600 /etc/smokeping/id_ed25519
 chmod 0644 /etc/smokeping/id_ed25519.pub
 
-# 3. Copy the public key to the router (one-time; will need the router password)
-scp /etc/smokeping/id_ed25519.pub smokeping@router.example.com:id_ed25519.pub
+# 3. Copy the public key to the router (one-time; needs a user with enough permissions to write the file)
+scp /etc/smokeping/id_ed25519.pub admin@router.example.com:id_ed25519.pub
 ```
 
 Then on the MikroTik router, as the admin or a user with `write` policy:
@@ -129,9 +129,6 @@ Then on the MikroTik router, as the admin or a user with `write` policy:
 
 # 5. (Optional) Verify the key is registered
 /user ssh-keys print where user=smokeping
-
-# 6. (Optional) Remove the uploaded file now that it's imported
-/file remove id_ed25519.pub
 ```
 
 Finally verify end-to-end from the smokeping host, still as root or the smokeping user:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ I wanted a probe to connect to Mikrotik RouterOS devices via SSH. So I created t
 - Do Not Fragment flag
 - Source SSH Port (Standard or Non-Standard)
 - User defined openssh-client path (/usr/bin/ssh)
+- SSH Key Authentication (with fallback to ssh-agent / default identity files)
 - Configurable SSH connect timeout (fail fast when router is unreachable)
 - Configurable SSH session timeout
 - Configurable SSH StrictHostKeyChecking policy (`yes` / `accept-new` / `no`)
@@ -92,6 +93,66 @@ Multiplexing is the ability to send more than one signal over a single line or c
 - Set/Filter the allowed IPs either in the IP->Services or set up a Firewall rule to permit SSH connections per your security policy
   
   ![Service2](https://github.com/tonydm/smokeping-OpenSSHMikrotikRouterOSPing/blob/master/screenshots/winbox-services-settings2.png)
+
+### SSH Key Authentication
+
+The probe supports three ways to authenticate to each Mikrotik target, chosen per-target:
+
+1. **Password** — set `routerospass` (the legacy default).
+2. **SSH key file** — set `ssh_key_path` to the private key path. Leave `routerospass` unset.
+3. **ssh-agent / default identity files** — leave both `routerospass` and `ssh_key_path` unset. Net::OpenSSH invokes the system ssh client which picks up `SSH_AUTH_SOCK`, `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, etc. — handy for containerised smokeping deployments that mount an agent socket.
+
+If none of the three are configured the connection fails at runtime with a Net::OpenSSH authentication error in the smokeping log.
+
+#### Generating a key and uploading it to the router
+
+Run these on the smokeping host, as root (or the user who will run smokeping):
+
+```
+# 1. Generate an unencrypted ed25519 key dedicated to smokeping
+ssh-keygen -t ed25519 -f /etc/smokeping/id_ed25519 -N '' -C smokeping-probe
+
+# 2. Lock down permissions (ssh refuses keys that are group/world-readable)
+chown smokeping:smokeping /etc/smokeping/id_ed25519 /etc/smokeping/id_ed25519.pub
+chmod 0600 /etc/smokeping/id_ed25519
+chmod 0644 /etc/smokeping/id_ed25519.pub
+
+# 3. Copy the public key to the router (one-time; will need the router password)
+scp /etc/smokeping/id_ed25519.pub smokeping@router.example.com:id_ed25519.pub
+```
+
+Then on the MikroTik router, as the admin or a user with `write` policy:
+
+```
+# 4. Associate the public key with the smokeping user account
+/user ssh-keys import public-key-file=id_ed25519.pub user=smokeping
+
+# 5. (Optional) Verify the key is registered
+/user ssh-keys print where user=smokeping
+
+# 6. (Optional) Remove the uploaded file now that it's imported
+/file remove id_ed25519.pub
+```
+
+Finally verify end-to-end from the smokeping host, still as root or the smokeping user:
+
+```
+sudo -u smokeping ssh -i /etc/smokeping/id_ed25519 smokeping@router.example.com
+```
+
+You should land on the `[smokeping@MikroTik] >` prompt without being asked for a password. Type `quit` to exit.
+
+Once that works, set `ssh_key_path = /etc/smokeping/id_ed25519` on the relevant smokeping target(s) and unset `routerospass`.
+
+> If the router password doesn't allow you to scp in step 3 (some hardened configurations disable password auth on the router ssh before a key is imported), upload `id_ed25519.pub` via Winbox Files instead, then run step 4 as normal.
+
+#### Using ssh-agent instead
+
+If smokeping runs in a container that already has `SSH_AUTH_SOCK` forwarded from the host (or some orchestrator injects it), leave both `routerospass` and `ssh_key_path` unset on the target. Net::OpenSSH will invoke ssh, which will try the agent first. Confirm it works with:
+
+```
+sudo -u smokeping ssh smokeping@router.example.com
+```
 
 ### Multiplexed SSH Connections
 
@@ -152,9 +213,10 @@ pings = 20
 # dscp_id = <id number> # Not used by default
 # rtable = <routing table name> # Not used by default
 # do_not_fragment = false # Not used by default
-routerospass = <userpass>
+routerospass = <userpass> # Optional.  Omit if using ssh_key_path or ssh-agent.
 routerosuser = <username>
 # ssh_binary_path = /usr/bin/ssh
+# ssh_key_path = /etc/smokeping/id_ed25519 # Optional.  If set, use key auth instead of routerospass.  See SSH Key Authentication section above.
 # ssh_connect_timeout = 10 # Default.  Bounds TCP/SSH handshake; lower this to fail faster on unreachable routers.
 # ssh_timeout = 60 # Default.  Bounds the overall ssh session including the ping command.
 # ssh_strict_host_key_checking = accept-new # Default.  Other values: 'no' (trust any key), 'yes' (require pre-seeded known_hosts)
@@ -207,15 +269,21 @@ debug = true
 debug_logfile = /tmp/smokeping_remote_router1.log
 
 ++ remote_router2
+# Key-auth example: this target overrides the probe-level password by setting ssh_key_path
+# and leaving routerospass unset.  See the "SSH Key Authentication" section above for setup.
 title = Remote Router2
 source = <remoterouter2_WAN_IP_Address>
 psource = <some_other_IP_address_on_remote_router>
 host = <IP_of_interest>
 rtable = <name_of_routing_table_other_than_main>
 ssh_port = 29437
+ssh_key_path = /etc/smokeping/id_ed25519
 multiplex_ssh = false # Don't use multiplexed ssh connections - but why would you not want to
 
 ++ remote_router3
+# ssh-agent example: with both routerospass and ssh_key_path unset (and not inherited from
+# the probe), Net::OpenSSH falls through to SSH_AUTH_SOCK / ~/.ssh/id_* identity files.
+# Useful when the smokeping process runs in a container with an agent socket mounted.
 title = Remote Router3
 source = <remoterouter3_WAN_IP_Address>
 host = <IP_of_interest>
@@ -235,11 +303,6 @@ multiplex_control_persist_time = 20 # Override to use 20 minutes
 ### Bugs
 
 - None reported
-
-### TODO
-
-- Add support 
-  - SSH Key Authentication
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ sudo -u smokeping ssh smokeping@router.example.com
 
 There are some requirements for this feature to work.  OpenSSH requires that the directory and it's parents, where the Master Control Socket File is created, must be writable only by the current effective user or root, otherwise the connection will be aborted to avoid insecure operation.  By default ~/.libnet-openssh-perl is used.
 
-This probe will attempt to determine the $HOME directory of the user running/executing Smokeping, usually "smokeping" or "root".  In some cases, if using Docker or other container platform.  For example, the user could be "abc" in the case of using s6-supervise.  You can override this behaviour and specify the directory where the Master Control Socket File is created by setting the multiplex_socket_file_path option in the Probes config file.  You must ensure that the path meets the requirements as previously stated and that the permission masks be 0755 or more restrictive so that no other user can write to the dir/file.
+This probe will attempt to determine the $HOME directory of the user running/executing Smokeping, usually "smokeping" or "root".  In some cases, if using Docker or other container platform.  For example, the user could be "abc" in the case of using s6-supervise.  You can override this behaviour and specify the directory where the Master Control Socket File is created by setting the multiplex_control_socket_path option in the Probes config file.  You must ensure that the path meets the requirements as previously stated and that the permission masks be 0755 or more restrictive so that no other user can write to the dir/file.
 
   - The error you will see in the smokeping.log (smokeping debug and logging enabled) if you have defined your own socket file path w/o properly setting up permissions:
 
@@ -222,7 +222,7 @@ routerosuser = <username>
 # ssh_strict_host_key_checking = accept-new # Default.  Other values: 'no' (trust any key), 'yes' (require pre-seeded known_hosts)
 multiplex_ssh = true # Default
 # multiplex_control_persist_time = 10 # Default is 10 min.  A value of 0 will leave socket file indefinitely
-# multiplex_control_file_path = ~/.libnet-openssh-perl # Default
+# multiplex_control_socket_path = ~/.libnet-openssh-perl # Default
 debug = false # Default
 debug_logfile = /tmp/smokeping_openssh_mtik.log
 ```
@@ -246,7 +246,7 @@ host = speedtest-nyc1.digitalocean.com
 # psource - uses parent defined
 rtable = secondary_wan
 # multiplex_ssh = true # Default
-multiplex_control_file_path = /tmp/smokeping_ssh_sockets
+multiplex_control_socket_path = /tmp/smokeping_ssh_sockets
 multiplex_control_persist_time = 0 # Indefinitely
 debug = true
 
@@ -293,7 +293,7 @@ dscp_id = 5
 do_not_fragment = true
 ssh_port = 29437
 # multiplex_ssh = true # Default behaviour
-multiplex_control_file_path = /tmp/smokeping_ssh_sockets # Override default ~/.libnet-openssh-perl
+multiplex_control_socket_path = /tmp/smokeping_ssh_sockets # Override default ~/.libnet-openssh-perl
 multiplex_control_persist_time = 20 # Override to use 20 minutes
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ If smokeping runs in a container that already has `SSH_AUTH_SOCK` forwarded from
 sudo -u smokeping ssh smokeping@router.example.com
 ```
 
+### Debugging
+
+Setting `debug = true` on a target emits a richer log to `debug_logfile` (default `/tmp/smokeping_debug.log`). Each probe cycle produces:
+
+- A `cycle start` line with the effective config snapshot (host, dest, user, auth method, multiplex, timeouts, strict-host-key policy).
+- The full composed ssh command the probe will execute — copy-paste this as the smokeping user to reproduce connection failures manually.
+- The raw ping response from the router.
+- The RouterOS `sent=N received=N packet-loss=N%` footer, cross-checked against the parser's sample count. A `WARN parser drift` line fires if they disagree — signal to investigate the regex.
+- A `cycle done` line with wall-clock timings for the three phases (`connect`, `command`, `parse`) and the total.
+
+For even deeper diagnostics, also set `debug_ssh = true` — this enables `-vvv` on the underlying ssh client and `$Net::OpenSSH::debug = -1`, dumping the full ssh protocol trace to the same file.
+
+> ⚠️ **Debug logs contain secrets.** With `debug = true` the probe dumps its full Net::OpenSSH options hash to `debug_logfile`, including `routerospass` in plaintext (when password auth is in use) and the on-disk path of `ssh_key_path` (when key auth is in use). Only enable debug on targets where the log file is readable by trusted operators, and scrub or redact logs before sharing them externally (support tickets, public issue trackers, pastebins). If you've been running with debug on historically, consider rotating any historical `debug_logfile` files whose contents may have been exposed.
+
 ### Multiplexed SSH Connections
 
 There are some requirements for this feature to work.  OpenSSH requires that the directory and it's parents, where the Master Control Socket File is created, must be writable only by the current effective user or root, otherwise the connection will be aborted to avoid insecure operation.  By default ~/.libnet-openssh-perl is used.


### PR DESCRIPTION
Fixed issue where replies with a non-empty STATUS column (e.g. "host unreachable" returned by an intermediate hop) were counted as successful pings. Adds SSH Key auth + defaults to accepting new SSH host keys. Adds some more ssh timing settings.